### PR TITLE
Add Docker-compose to spin up and link containers.

### DIFF
--- a/OnlineShop_AspNetCore_ReactJS/docker-compose.yaml
+++ b/OnlineShop_AspNetCore_ReactJS/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '2.0'
+services:
+  web:
+    build: .
+    ports:
+    - "8080:8080"
+    depends_on:
+    - mongo
+  mongo:
+    image: mongo
+    ports:
+        - "27017:27017"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ There are two ways to run the code locally:
 
 ## Run using Docker Compose
 
+Prerequisite:
+
+1. Make sure that docker componse is installed on the host. Refer to the [link](https://docs.docker.com/compose/install/) for installation.
+
+Steps:
+
 1. Open Bash (Linux shell) and navigate to code folder where Dockerfile is present, execute `cd OnlineShop_AspNetCore_ReactJS/OnlineShop_AspNetCore_ReactJS/`
 
 2. execute `docker-compose up -d`

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ There are two ways to run the code locally:
 
 5. To test the REST Apis navigate to [SwaggerUI](http://localhost:8080/swagger/index.html)
 
+## Run using Docker Compose
+
+1. Open Bash (Linux shell) and navigate to code folder where Dockerfile is present, execute `cd OnlineShop_AspNetCore_ReactJS/OnlineShop_AspNetCore_ReactJS/`
+
+2. execute `docker-compose up -d`
+
+3. Open the browser and navigate to [http://localhost:8080/](http://localhost:8080/)
+
+4. To test the REST Apis navigate to [SwaggerUI](http://localhost:8080/swagger/index.html)
+
+5. This also runs the mongodb container which is exposed on the default mongo db port on the host.
+
 ## To Run without Docker
 
 1. Navigate to ClientApp folder, execute `cd OnlineShop_AspNetCore_ReactJS\OnlineShop_AspNetCore_ReactJS\ClientApp`


### PR DESCRIPTION
- Added docker compose to spin up web and mongodb container.
- Extra work would be needed to have the dotnet app talk to the mongo db, and also, the migration script being run on mongodb after the container startup, before the app starts to talk to the database.